### PR TITLE
Update to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,22 @@
 
 ## Info
 
-**Document version:** 2.2.2
+**Document version:** 2.3.0
 
-**Last updated:** 03/02/2017
+**Last updated:** 03/24/2017
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.3.0
+
+- Reduce memory pressure w/ `@autoreleasepool` blocks on GCD queues in _TIP_
+- Add "problem" for images not caching because they are too large
+- Add "problem" when downloaded image cannot be decoded
+- Add Animated PNG support (iOS 8+)
+- Add the store operation as an argument to `TIPImagePipelineStoreCompletionBlock`
+- Tightened up some threading race conditions that cropped up with the thread sanitizer
 
 ### 2.2.2
 

--- a/TwitterImagePipeline.podspec
+++ b/TwitterImagePipeline.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TwitterImagePipeline'
-  s.version          = '2.2.2'
+  s.version          = '2.3.0'
   s.summary          = 'Twitter Image Pipeline is a robust and performant image loading and caching framework for iOS'
   s.description      = 'Twitter created a framework for image loading/caching in order to fulfill the numerous needs of Twitter for iOS including being fast, safe, modular and versatile.'
   s.homepage         = 'https://github.com/twitter/ios-twitter-logging-service'

--- a/TwitterImagePipeline.xcodeproj/project.pbxproj
+++ b/TwitterImagePipeline.xcodeproj/project.pbxproj
@@ -1058,7 +1058,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B63017F1E68F9B400C9A86A = {
@@ -1442,8 +1442,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(PROJECT_DIR)/TwitterImagePipelineTests",
-					"\"$(PLATFORM_DIR)/Developer/Library/Frameworks\"",
 				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1481,8 +1481,8 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(PROJECT_DIR)/TwitterImagePipelineTests",
-					"\"$(PLATFORM_DIR)/Developer/Library/Frameworks\"",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = TwitterImagePipelineTests/TIPTests.Info.plist;
@@ -1623,7 +1623,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.2;
+				CURRENT_PROJECT_VERSION = 2.3;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
@@ -1648,7 +1648,11 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(OBJROOT)/UninstalledProducts/$(PLATFORM_NAME)/include",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MODULE_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1683,7 +1687,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CURRENT_PROJECT_VERSION = 2.2;
+				CURRENT_PROJECT_VERSION = 2.3;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
@@ -1702,13 +1706,16 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(OBJROOT)/UninstalledProducts/$(PLATFORM_NAME)/include",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MODULE_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1717,7 +1724,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/TwitterImagePipeline;
 				RUN_CLANG_STATIC_ANALYZER = "$(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))";
@@ -1729,7 +1735,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/TwitterImagePipeline;
 				RUN_CLANG_STATIC_ANALYZER = "$(RUN_CLANG_STATIC_ANALYZER_FOR_$(PRODUCT_NAME))";
@@ -1741,6 +1746,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TwitterImagePipelineTests",
+				);
 				INFOPLIST_FILE = TwitterImagePipelineTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1757,6 +1766,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/TwitterImagePipelineTests",
+				);
 				INFOPLIST_FILE = TwitterImagePipelineTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TIP Sample App.xcscheme
+++ b/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TIP Sample App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TIP Swift Sample App.xcscheme
+++ b/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TIP Swift Sample App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TwitterImagePipeline.xcscheme
+++ b/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TwitterImagePipeline.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TwitterImagePipelineTests.xcscheme
+++ b/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TwitterImagePipelineTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BFBD3511AA77DB2007A08DD"
+               BuildableName = "TwitterImagePipelineTests.xctest"
+               BlueprintName = "TwitterImagePipelineTests"
+               ReferencedContainer = "container:TwitterImagePipeline.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TwitterImagePipeline/Project/NSOperationQueue+TIPSafety.m
+++ b/TwitterImagePipeline/Project/NSOperationQueue+TIPSafety.m
@@ -23,7 +23,10 @@ static NSTimeInterval const TIPOperationSafetyGuardCheckForAlreadyFinishedOperat
 
 - (void)tip_safeAddOperation:(NSOperation *)op
 {
-    [[TIPOperationSafetyGuard operationSafetyGuard] addOperation:op];
+    TIPOperationSafetyGuard *guard = [TIPOperationSafetyGuard operationSafetyGuard];
+    if (guard) {
+        [guard addOperation:op];
+    }
     [self addOperation:op];
 }
 

--- a/TwitterImagePipeline/Project/TIPGlobalConfiguration+Project.h
+++ b/TwitterImagePipeline/Project/TIPGlobalConfiguration+Project.h
@@ -38,8 +38,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) SInt64 internalTotalBytesForAllRenderedCaches;
 
 // shared queues
+// The TIP caches can execute a LOT of Cocoa code which can pile up with autoreleases.
+// Since queues don't immediately clear their autorelease pools, the time when these objects
+// will be disposed is undefined and can be very long lived.
+// Given the amount of large objects in TIP (images), we will be agressive with our autoreleasing
+// and will use `tip_dispatch_[a]sync_autoreleasing` functions to wrap TIP cache queue block
+// execution with `@autoreleasepool`.
 @property (nonatomic, readonly) dispatch_queue_t queueForMemoryCaches;
 @property (nonatomic, readonly) dispatch_queue_t queueForDiskCaches;
+- (dispatch_queue_t)queueForCachesOfType:(TIPImageCacheType)type;
 
 // other properties
 @property (atomic, nonnull, readonly) NSArray<id<TIPImagePipelineObserver>> *allImagePipelineObservers;
@@ -47,7 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL imageFetchDownloadProviderSupportsStubbing;
 
 // per cache type accessors
-- (dispatch_queue_t)queueForCachesOfType:(TIPImageCacheType)type;
 - (SInt16)internalMaxCountForAllCachesOfType:(TIPImageCacheType)type;
 - (SInt16)internalTotalCountForAllCachesOfType:(TIPImageCacheType)type;
 - (SInt64)internalMaxBytesForAllCachesOfType:(TIPImageCacheType)type;

--- a/TwitterImagePipeline/Project/TIPImageStoreOperation.h
+++ b/TwitterImagePipeline/Project/TIPImageStoreOperation.h
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TIPImageStoreHydrationOperation : TIPDisabledExternalMutabilityOperation
 
-@property (nonatomic, readonly) NSError *error;
-@property (nonatomic, readonly) id<TIPImageStoreRequest> hydratedRequest;
+@property (nonatomic, readonly, nullable) NSError *error;
+@property (nonatomic, readonly, nullable) id<TIPImageStoreRequest> hydratedRequest;
 
 - (instancetype)initWithRequest:(id<TIPImageStoreRequest>)request pipeline:(TIPImagePipeline *)pipeline hydrater:(id<TIPImageStoreRequestHydrater>)hydrater;
 

--- a/TwitterImagePipeline/Project/TIPLRUCache.h
+++ b/TwitterImagePipeline/Project/TIPLRUCache.h
@@ -31,7 +31,7 @@
 
 - (void)appendEntry:(nonnull id<TIPLRUEntry>)entry;
 
-- (void)removeEntry:(nonnull id<TIPLRUEntry>)entry;
+- (void)removeEntry:(nullable id<TIPLRUEntry>)entry;
 
 - (nullable id<TIPLRUEntry>)removeTailEntry;
 
@@ -43,6 +43,7 @@
 
 @optional
 - (void)tip_cache:(nonnull TIPLRUCache *)cache didEvictEntry:(nonnull id<TIPLRUEntry>)entry;
+- (BOOL)tip_cache:(nonnull TIPLRUCache *)cache canEvictEntry:(nonnull id<TIPLRUEntry>)entry;
 
 @end
 

--- a/TwitterImagePipeline/Project/TIPPartialImage.h
+++ b/TwitterImagePipeline/Project/TIPPartialImage.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSInteger, TIPPartialImageState) {
 @interface TIPPartialImage : NSObject
 
 // State
-@property (nonatomic, readonly) TIPPartialImageState state;
+@property (atomic, readonly) TIPPartialImageState state;
 @property (nonatomic, readonly) NSUInteger expectedContentLength;
 
 // After headers are read

--- a/TwitterImagePipeline/Project/TIP_Project.m
+++ b/TwitterImagePipeline/Project/TIP_Project.m
@@ -23,6 +23,8 @@ NSString * const TIPProblemImageFailedToScale = @"TIPProblemImageFailedToScale";
 NSString * const TIPProblemImageContainerHasNilImage = @"TIPProblemImageContainerHasNilImage";
 NSString * const TIPProblemImageFetchHasInvalidTargetDimensions = @"TIPProblemImageFetchHasInvalidTargetDimensions";
 NSString * const TIPProblemImageDownloadedHasGPSInfo = @"TIPProblemImageDownloadedHasGPSInfo";
+NSString * const TIPProblemImageDownloadedCouldNotBeDecoded = @"TIPProblemImageDownloadedCouldNotBeDecoded";
+NSString * const TIPProblemImageTooLargeToStoreInDiskCache = @"TIPProblemImageTooLargeToStoreInDiskCache";
 
 #pragma mark Problem User Info Keys
 
@@ -38,7 +40,7 @@ NSString * const TIPProblemInfoKeyImageIsAnimated = @"animated";
 
 NSString *TIPVersion()
 {
-    return @"2.2";
+    return @"2.3";
 }
 
 void TIPSwizzle(Class cls, SEL originalSelector, SEL swizzledSelector)

--- a/TwitterImagePipeline/TIPError.h
+++ b/TwitterImagePipeline/TIPError.h
@@ -194,6 +194,10 @@ FOUNDATION_EXTERN NSString * const TIPProblemImageContainerHasNilImage;
 FOUNDATION_EXTERN NSString * const TIPProblemImageFetchHasInvalidTargetDimensions;
 //! Problem that a downloaded image has GPS info
 FOUNDATION_EXTERN NSString * const TIPProblemImageDownloadedHasGPSInfo;
+//! Problem decoding downloaded image
+FOUNDATION_EXTERN NSString * const TIPProblemImageDownloadedCouldNotBeDecoded;
+//! Problem when attempting to store an image to disk cache due to size limit
+FOUNDATION_EXTERN NSString * const TIPProblemImageTooLargeToStoreInDiskCache;
 
 #pragma mark Problem Info Keys
 

--- a/TwitterImagePipeline/TIPImageFetchOperation.m
+++ b/TwitterImagePipeline/TIPImageFetchOperation.m
@@ -914,7 +914,7 @@ TIPStaticAssert(sizeof(TIPImageFetchOperationState_Unaligned_AtomicT) == sizeof(
     NSMutableDictionary<NSString *, TIPImagePipeline *> *pipelines = [[TIPImagePipeline allRegisteredImagePipelines] mutableCopy];
     [pipelines removeObjectForKey:_imagePipeline.identifier];
     NSArray<TIPImagePipeline *> *otherPipelines = [pipelines allValues];
-    dispatch_async([TIPGlobalConfiguration sharedInstance].queueForDiskCaches, ^{
+    tip_dispatch_async_autoreleasing([TIPGlobalConfiguration sharedInstance].queueForDiskCaches, ^{
         [self _tip_diskCache_loadFromOtherPipelines:otherPipelines startMachTime:mach_absolute_time()];
     });
 }

--- a/TwitterImagePipeline/TIPImagePipeline.h
+++ b/TwitterImagePipeline/TIPImagePipeline.h
@@ -21,7 +21,7 @@
 //! Completion block for a `TIPImageFetchOperation` that didn't use a delegate
 typedef void(^TIPImagePipelineFetchCompletionBlock)(id<TIPImageFetchResult> __nullable finalResult,  NSError * __nullable error);
 //! Completion block for an image store
-typedef void(^TIPImagePipelineStoreCompletionBlock)(BOOL succeeded, NSError * __nullable error);
+typedef void(^TIPImagePipelineStoreCompletionBlock)(NSObject<TIPDependencyOperation> * __nonnull storeOp, BOOL succeeded, NSError * __nullable error);
 //! Completion block for copying a file from an image pipeline's disk cache to a _temporaryFilePath_
 typedef void(^TIPImagePipelineCopyFileCompletionBlock)(NSString * __nullable temporaryFilePath, NSError * __nullable error);
 

--- a/TwitterImagePipeline/TIPImagePipeline.m
+++ b/TwitterImagePipeline/TIPImagePipeline.m
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_END
     NSString *_imagePipelinePath;
 }
 
-// the following getters may appear superfluous, and would be if it weren't for the need to
+// the following getters may appear superfluous, and would be, if it weren't for the need to
 // annotate them with __attribute__((no_sanitize("thread")).  the getters make the @synthesize
 // lines necessary.
 //
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_END
 
 + (void)getKnownImagePipelineIdentifiers:(void (^)(NSSet<NSString *> *identifiers))callback
 {
-    dispatch_async([TIPGlobalConfiguration sharedInstance].queueForDiskCaches, ^{
+    tip_dispatch_async_autoreleasing([TIPGlobalConfiguration sharedInstance].queueForDiskCaches, ^{
         NSMutableSet *identifiers = [[NSMutableSet alloc] init];
         NSFileManager *fm = [NSFileManager defaultManager];
         NSString *pipelineDir = TIPImagePipelinePath();
@@ -301,8 +301,8 @@ NS_ASSUME_NONNULL_END
 - (void)_tip_background_copyDiskCacheFileWithIdentifier:(nonnull NSString *)imageIdentifier completion:(nullable TIPImagePipelineCopyFileCompletionBlock)completion
 {
     // Copy to temp location
-    NSString *temporaryFile;
-    NSError *error;
+    NSString *temporaryFile = nil;
+    NSError *error = nil;
     temporaryFile = [self.diskCache copyImageEntryFileForIdentifier:imageIdentifier error:&error];
 
     // Indicate completion

--- a/TwitterImagePipeline/TIPImageTypes.h
+++ b/TwitterImagePipeline/TIPImageTypes.h
@@ -29,6 +29,7 @@ FOUNDATION_EXTERN NSString * const TIPImageTypeJPEG;
 FOUNDATION_EXTERN NSString * const TIPImageTypeJPEG2000;
 /**
  PNG (Portable Network Graphic)
+ Animation encoding/decoding _is_ supported by _TIP_ by default (on iOS 8+).
  PNG has a way of being encoded progressively (interlaced/Adam7).
  Progressive decoding _is not_ supported by __TIP__ by default,
  a custom `TIPImageCodec` would be required to add progressive decoding support.

--- a/TwitterImagePipelineTests/TIPImagePipelineTests.m
+++ b/TwitterImagePipelineTests/TIPImagePipelineTests.m
@@ -606,10 +606,10 @@ static TIPImagePipeline *sPipeline = nil;
         XCTAssertEqual(sPipeline.memoryCache.manifest.numberOfEntries, (NSUInteger)0);
         XCTAssertEqual(sPipeline.diskCache.manifest.numberOfEntries, (NSUInteger)0);
 
-        dispatch_sync(config.queueForDiskCaches, ^{
+        dispatch_sync([TIPGlobalConfiguration sharedInstance].queueForDiskCaches, ^{
             preDeallocDiskSize = config.internalTotalBytesForAllDiskCaches;
         });
-        dispatch_sync(config.queueForMemoryCaches, ^{
+        dispatch_sync([TIPGlobalConfiguration sharedInstance].queueForMemoryCaches, ^{
             preDeallocMemSize = config.internalTotalBytesForAllMemoryCaches;
         });
         preDeallocRendSize = config.internalTotalBytesForAllRenderedCaches;
@@ -642,10 +642,10 @@ static TIPImagePipeline *sPipeline = nil;
     for (cacheSizeCheck = 1; cacheSizeCheck <= cacheSizeCheckMax; cacheSizeCheck++) {
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
 
-        dispatch_sync(config.queueForDiskCaches, ^{
+        dispatch_sync([TIPGlobalConfiguration sharedInstance].queueForDiskCaches, ^{
             postDeallocDiskSize = config.internalTotalBytesForAllDiskCaches;
         });
-        dispatch_sync(config.queueForMemoryCaches, ^{
+        dispatch_sync([TIPGlobalConfiguration sharedInstance].queueForMemoryCaches, ^{
             postDeallocMemSize = config.internalTotalBytesForAllMemoryCaches;
         });
         postDeallocRendSize = config.internalTotalBytesForAllRenderedCaches;
@@ -917,7 +917,7 @@ static TIPImagePipeline *sPipeline = nil;
     [sPipeline clearDiskCache];
     [sPipeline clearMemoryCaches];
 
-    NSString * copyFinishedNotificationName = @"copy_finished";
+    NSString *copyFinishedNotificationName = @"copy_finished";
 
     TIPImagePipelineTestFetchRequest *request = [[TIPImagePipelineTestFetchRequest alloc] init];
     request.imageURL = [TIPImagePipelineTests dummyURLWithPath:[NSUUID UUID].UUIDString];
@@ -1007,7 +1007,7 @@ static TIPImagePipeline *sPipeline = nil;
 
     expectation = [self expectationWithDescription:@"Storing Image"];
     TIPImagePipeline *pipeline = [[TIPImagePipeline alloc] initWithIdentifier:signalIdentifier];
-    [pipeline storeImageWithRequest:storeRequest completion:^(BOOL succeeded, NSError *error) {
+    [pipeline storeImageWithRequest:storeRequest completion:^(NSObject<TIPDependencyOperation> *storeOp, BOOL succeeded, NSError *error) {
         didStore = succeeded;
         [expectation fulfill];
     }];
@@ -1065,7 +1065,7 @@ static TIPImagePipeline *sPipeline = nil;
     [self waitForExpectationsWithTimeout:10.0 handler:NULL];
 
     expectation = [self expectationWithDescription:@"Cross Pipeline Store Image"];
-    [pipeline1 storeImageWithRequest:storeRequest completion:^(BOOL succeeded, NSError *error) {
+    [pipeline1 storeImageWithRequest:storeRequest completion:^(NSObject<TIPDependencyOperation> *storeOp, BOOL succeeded, NSError *error) {
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:10.0 handler:NULL];

--- a/TwitterImagePipelineTests/TIPImageTest.m
+++ b/TwitterImagePipelineTests/TIPImageTest.m
@@ -707,6 +707,27 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSNumber 
     }];
 }
 
+- (void)testSaveAnimatedPNG
+{
+    [self runMeasurement:@"save" format:@"apng" block:^{
+        [self runSaveTest:TIPImageTypePNG options:0 extension:@"apng" quality:1.0f useAnimatedImage:YES];
+    }];
+}
+
+- (void)testXLoadAnimatedPNG
+{
+    [self runMeasurement:@"load" format:@"apng" block:^{
+        [self runLoadTest:TIPImageTypePNG options:0 extension:@"apng" quality:1.0f isAnimated:YES];
+    }];
+}
+
+- (void)testSpeedAnimatedPNG
+{
+    [self runMeasurement:@"speed" format:@"apng" block:^{
+        [self runSpeedTest:TIPImageTypePNG options:0];
+    }];
+}
+
 #pragma mark Robustness Tests
 
 - (void)testDataDribbleJPEG

--- a/TwitterImagePipelineTests/TIPXWebPCodec.h
+++ b/TwitterImagePipelineTests/TIPXWebPCodec.h
@@ -8,6 +8,8 @@
 
 #import <TwitterImagePipeline/TIPImageCodecs.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 //! Custom image type for WebP, `@"google.webp"`
 FOUNDATION_EXTERN NSString * const TIPXImageTypeWebP;
 
@@ -23,3 +25,5 @@ FOUNDATION_EXTERN NSString * const TIPXImageTypeWebP;
 /** WebP encoder */
 @property (nonatomic, readonly) id<TIPImageEncoder> tip_encoder;
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Reduce memory pressure w/ `@autoreleasepool` blocks on GCD queues in _TIP_
- Add "problem" for images not caching because they are too large
- Add "problem" when downloaded image cannot be decoded
- Add Animated PNG support (iOS 8+)
- Add the store operation as an argument to `TIPImagePipelineStoreCompletionBlock`
- Tightened up some threading race conditions that cropped up with the thread sanitizer
- Fix edge case where memory cache can exceed max cache size
- Other miscellaneous fixes
- update to Xcode 8.3