### PR TITLE
Support encoding non-RGBA pixel formats to WebP

### DIFF
--- a/TwitterImagePipelineTests/TIPXWebPCodec.m
+++ b/TwitterImagePipelineTests/TIPXWebPCodec.m
@@ -445,7 +445,8 @@ static BOOL TIPXWebPPictureImport(WebPPicture *picture, CGImageRef imageRef)
     return WebPPictureImportRGBA(picture, convertedImageBuffer.data, (int)convertedImageBuffer.rowBytes);
 }
 
-static BOOL TIPXWebPCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer *convertedImageBuffer) {
+static BOOL TIPXWebPCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer *convertedImageBuffer)
+{
     if (convertedImageBuffer == NULL) {
         return NO;
     }
@@ -460,7 +461,7 @@ static BOOL TIPXWebPCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer
     CGColorSpaceRef deviceRGBColorSpace = CGColorSpaceCreateDeviceRGB();
     TIPXDeferRelease(deviceRGBColorSpace);
 
-    vImage_CGImageFormat destinationImageFormat = {
+    vImage_CGImageFormat convertedImageFormat = {
         .bitsPerComponent = 8,
         .bitsPerPixel = 32,
         .colorSpace = deviceRGBColorSpace,
@@ -478,11 +479,11 @@ static BOOL TIPXWebPCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer
         return NO;
     }
 
-    if (vImageBuffer_Init(convertedImageBuffer, sourceImageBuffer.width, sourceImageBuffer.height, destinationImageFormat.bitsPerPixel, kvImageNoFlags) != kvImageNoError) {
+    if (vImageBuffer_Init(convertedImageBuffer, sourceImageBuffer.width, sourceImageBuffer.height, convertedImageFormat.bitsPerPixel, kvImageNoFlags) != kvImageNoError) {
         return NO;
     }
 
-    vImageConverterRef imageConverter = vImageConverter_CreateWithCGImageFormat(&sourceImageFormat, &destinationImageFormat, NULL, kvImageNoFlags, NULL);
+    vImageConverterRef imageConverter = vImageConverter_CreateWithCGImageFormat(&sourceImageFormat, &convertedImageFormat, NULL, kvImageNoFlags, NULL);
 
     if (imageConverter == NULL) {
         return NO;

--- a/TwitterImagePipelineTests/TIPXWebPCodec.m
+++ b/TwitterImagePipelineTests/TIPXWebPCodec.m
@@ -479,7 +479,7 @@ static BOOL TIPXWebPCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer
         return NO;
     }
 
-    if (vImageBuffer_Init(convertedImageBuffer, sourceImageBuffer.width, sourceImageBuffer.height, convertedImageFormat.bitsPerPixel, kvImageNoFlags) != kvImageNoError) {
+    if (vImageBuffer_Init(convertedImageBuffer, sourceImageBuffer.height, sourceImageBuffer.width, convertedImageFormat.bitsPerPixel, kvImageNoFlags) != kvImageNoError) {
         return NO;
     }
 

--- a/TwitterImagePipelineTests/TIPXWebPCodec.m
+++ b/TwitterImagePipelineTests/TIPXWebPCodec.m
@@ -9,6 +9,7 @@
 #import <TwitterImagePipeline/TwitterImagePipeline.h>
 #import <WebP/decode.h>
 #import <WebP/encode.h>
+#import <Accelerate/Accelerate.h>
 #import "TIPXWebPCodec.h"
 
 #pragma mark - Constants
@@ -39,6 +40,8 @@ __strong tipx_defer_block_t tipx_macro_concat(tipx_stack_defer_block_, __LINE__)
 #pragma mark - Declarations
 
 static TIPImageContainer * __nullable TIPXWebPConstructImageContainer(CGDataProviderRef dataProvider, const size_t width, const size_t height, const size_t bytesPerPixel, const size_t componentsPerPixel);
+static int TIPXWebPPictureImport(WebPPicture *picture, CGImageRef imageRef);
+static int TIPXCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer *convertedImageBuffer);
 
 @interface TIPXWebPDecoderContext : NSObject <TIPImageDecoderContext>
 
@@ -155,11 +158,7 @@ static TIPImageContainer * __nullable TIPXWebPConstructImageContainer(CGDataProv
     __block WebPPicture *pictureRef = NULL;
     __block TIPErrorCode errorCode = TIPErrorCodeUnknown;
     __block NSData *outputData = nil;
-    __block CFDataRef dataRef = NULL;
     tipx_defer(^{
-        if (dataRef) {
-            CFRelease(dataRef);
-        }
         if (pictureRef) {
             WebPPictureFree(pictureRef);
         }
@@ -180,12 +179,6 @@ static TIPImageContainer * __nullable TIPXWebPConstructImageContainer(CGDataProv
         return nil;
     }
 
-    CGDataProviderRef dataProvider = CGImageGetDataProvider(imageRef);
-    dataRef = CGDataProviderCopyData(dataProvider);
-    if (!dataRef) {
-        return nil;
-    }
-
     WebPConfig config;
     if (!WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality * 100.f)) {
         return nil;
@@ -202,19 +195,15 @@ static TIPImageContainer * __nullable TIPXWebPConstructImageContainer(CGDataProv
     }
     pictureRef = &pictureStruct;
 
-    const size_t bytesPerRow = CGImageGetBytesPerRow(imageRef);
     const size_t width = CGImageGetWidth(imageRef);
     const size_t height = CGImageGetHeight(imageRef);
 
     pictureRef->width = (int)width;
     pictureRef->height = (int)height;
 
-    if (!WebPPictureImportRGBA(pictureRef, (uint8_t *)CFDataGetBytePtr(dataRef), (int)bytesPerRow)) {
+    if (!TIPXWebPPictureImport(pictureRef, imageRef)) {
         return nil;
     }
-
-    CFRelease(dataRef);
-    dataRef = NULL;
 
     WebPMemoryWriter *writerRef = (WebPMemoryWriter *)malloc(sizeof(WebPMemoryWriter));
     WebPMemoryWriterInit(writerRef);
@@ -437,4 +426,69 @@ static TIPImageContainer *TIPXWebPConstructImageContainer(CGDataProviderRef data
         return nil;
     }
     return [[TIPImageContainer alloc] initWithImage:image];
+}
+
+static int TIPXWebPPictureImport(WebPPicture *picture, CGImageRef imageRef)
+{
+    __block vImage_Buffer convertedImageBuffer;
+
+    tipx_defer(^{
+        if (convertedImageBuffer.data) {
+            free(convertedImageBuffer.data);
+        }
+    });
+
+    if (!TIPXCreateRGBADataForImage(imageRef, &convertedImageBuffer)) {
+        return 1;
+    }
+
+    return WebPPictureImportRGBA(picture, convertedImageBuffer.data, (int)convertedImageBuffer.rowBytes);
+}
+
+static int TIPXCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer *convertedImageBuffer) {
+    if (convertedImageBuffer == NULL) {
+        return 1;
+    }
+
+    vImage_CGImageFormat sourceImageFormat = {
+        .bitsPerComponent = (uint32_t)CGImageGetBitsPerComponent(sourceImage),
+        .bitsPerPixel = (uint32_t)CGImageGetBitsPerPixel(sourceImage),
+        .colorSpace = CGImageGetColorSpace(sourceImage),
+        .bitmapInfo = CGImageGetBitmapInfo(sourceImage)
+    };
+
+    vImage_CGImageFormat destinationImageFormat = {
+        .bitsPerComponent = 8,
+        .bitsPerPixel = 32,
+        .colorSpace = CGColorSpaceCreateDeviceRGB(),
+        .bitmapInfo = kCGImageByteOrder32Big | kCGImageAlphaLast
+    };
+
+    __block vImage_Buffer sourceImageBuffer;
+
+    tipx_defer(^{
+        if (sourceImageBuffer.data) {
+            free(sourceImageBuffer.data);
+        }
+    });
+
+    if (vImageBuffer_InitWithCGImage(&sourceImageBuffer, &sourceImageFormat, NULL, sourceImage, kvImageNoFlags) != kvImageNoError) {
+        return 1;
+    }
+
+    if (vImageBuffer_Init(convertedImageBuffer, sourceImageBuffer.width, sourceImageBuffer.height, destinationImageFormat.bitsPerPixel, kvImageNoFlags) != kvImageNoError) {
+        return 1;
+    }
+
+    vImageConverterRef imageConverter = vImageConverter_CreateWithCGImageFormat(&sourceImageFormat, &destinationImageFormat, NULL, kvImageNoFlags, NULL);
+    
+    if (imageConverter == NULL) {
+        return 1;
+    }
+    
+    if (vImageConvert_AnyToAny(imageConverter, &sourceImageBuffer, convertedImageBuffer, NULL, kvImageNoFlags) != kvImageNoError) {
+        return 1;
+    }
+    
+    return 0;
 }

--- a/TwitterImagePipelineTests/TIPXWebPCodec.m
+++ b/TwitterImagePipelineTests/TIPXWebPCodec.m
@@ -465,7 +465,7 @@ static BOOL TIPXWebPCreateRGBADataForImage(CGImageRef sourceImage, vImage_Buffer
         .bitsPerComponent = 8,
         .bitsPerPixel = 32,
         .colorSpace = deviceRGBColorSpace,
-        .bitmapInfo = kCGImageByteOrder32Big | kCGImageAlphaLast
+        .bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaLast
     };
 
     __block vImage_Buffer sourceImageBuffer = {};

--- a/TwitterImagePipelineTests/TIPXWebPCodec.m
+++ b/TwitterImagePipelineTests/TIPXWebPCodec.m
@@ -6,10 +6,10 @@
 //  Copyright © 2016 Twitter. All rights reserved.
 //
 
+#import <Accelerate/Accelerate.h>
 #import <TwitterImagePipeline/TwitterImagePipeline.h>
 #import <WebP/decode.h>
 #import <WebP/encode.h>
-#import <Accelerate/Accelerate.h>
 #import "TIPXWebPCodec.h"
 
 #pragma mark - Constants


### PR DESCRIPTION
Whilst using `TIPXWebPEncoder`, I noticed that some `UIImage`s will have their red and blue channels swapped in the resulting WebP image data. This is due to the underlying pixel data being in BGRA format as opposed to RGBA.

To fix this, I've added in some code to convert images to standard RGBA format using `Accelerate.framework`'s `vImage` functions before importing it into the WebP.