### PR TITLE
Allow `tip_fetchedImage` to know about how it was set

### DIFF
--- a/TwitterImagePipeline/TIPImageViewFetchHelper.m
+++ b/TwitterImagePipeline/TIPImageViewFetchHelper.m
@@ -726,7 +726,6 @@ NS_INLINE BOOL TIPIsViewVisible(UIView * __nullable view)
         TIPAssertMessage((0b11111110 & placeholder) == 0b0, @"Cannot set a 1-bit flag with a BOOL that isn't 1 bit");
     }
 
-    self.fetchView.tip_fetchedImage = image;
     self.fetchSource = source;
     _fetchedImageURL = URL;
     _flags.isLoadedImageFinal = final;
@@ -747,6 +746,7 @@ NS_INLINE BOOL TIPIsViewVisible(UIView * __nullable view)
         self.fetchProgress = progress;
         [self _tip_didUpdateProgress:progress];
     }
+    self.fetchView.tip_fetchedImage = image;
     if (image) {
         [self _tip_didUpdateDisplayedImage:image fromSourceDimensions:sourceDimensions isFinal:final || scaled];
     }


### PR DESCRIPTION
By setting `tip_fetchedImage` after setting `fetchSource` and `_flags`, an implementation of `tip_fetchedImage` can ask the `TIPImageViewFetchHelper` about where it came from, it's progress, etc. One use of this is being able to animate the setting of the image if the source was from the network.