### PR TITLE
Update to v2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 ## Info
 
-**Document version:** 2.12.0
+**Document version:** 2.12.1
 
-**Last updated:** 12/18/2018
+**Last updated:** 01/22/2018
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.12.1
+
+- Fix bugs related to capping the sizes of caches
+  - Capping a cache to `0` bytes would not completely disable it as documented, fixed
+  - Setting the max ratio value to a negative value would not use the default value as documented, fixed
+  - Thanks to @jml5qh for filing this issue (#41)
 
 ### 2.12.0
 

--- a/TwitterImagePipeline.podspec
+++ b/TwitterImagePipeline.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'TwitterImagePipeline'
-  s.version          = '2.12.0'
-  s.compiler_flags   = '-DTIP_PROJECT_VERSION=2.12.0'
+  s.version          = '2.12.1'
+  s.compiler_flags   = '-DTIP_PROJECT_VERSION=2.12'
   s.summary          = 'Twitter Image Pipeline is a robust and performant image loading and caching framework for iOS'
   s.description      = 'Twitter created a framework for image loading/caching in order to fulfill the numerous needs of Twitter for iOS including being fast, safe, modular and versatile.'
   s.homepage         = 'https://github.com/twitter/ios-twitter-image-pipeline'

--- a/TwitterImagePipeline.xcodeproj/project.pbxproj
+++ b/TwitterImagePipeline.xcodeproj/project.pbxproj
@@ -1305,10 +1305,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B6511D92135DE7300ED057B /* Build configuration list for PBXNativeTarget "TwitterImagePipeline.framework tvOS" */;
 			buildPhases = (
+				8B6511BB2135DE7300ED057B /* Headers */,
 				8B6511952135DE7300ED057B /* Sources */,
 				8B6511BA2135DE7300ED057B /* Frameworks */,
-				8B6511BB2135DE7300ED057B /* Headers */,
-				8B6511D82135DE7300ED057B /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1323,10 +1322,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B6511F82135DEB400ED057B /* Build configuration list for PBXNativeTarget "TIPTests tvOS" */;
 			buildPhases = (
+				8B6511F12135DEB400ED057B /* Headers */,
 				8B6511E12135DEB400ED057B /* Sources */,
 				8B6511ED2135DEB400ED057B /* Frameworks */,
-				8B6511F12135DEB400ED057B /* Headers */,
-				8B6511F72135DEB400ED057B /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1379,10 +1377,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8BA9755C1D77E2CA00601D70 /* Build configuration list for PBXNativeTarget "TIPTests" */;
 			buildPhases = (
+				8BA975501D77E2C900601D70 /* Headers */,
 				8BA9754E1D77E2C900601D70 /* Sources */,
 				8BA9754F1D77E2C900601D70 /* Frameworks */,
-				8BA975501D77E2C900601D70 /* Headers */,
-				8BA975511D77E2C900601D70 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1471,10 +1468,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8BFF17751DF5B4AD005DE734 /* Build configuration list for PBXNativeTarget "TwitterImagePipeline.framework" */;
 			buildPhases = (
+				8BFF17671DF5B4AD005DE734 /* Headers */,
 				8BFF17651DF5B4AD005DE734 /* Sources */,
 				8BFF17661DF5B4AD005DE734 /* Frameworks */,
-				8BFF17671DF5B4AD005DE734 /* Headers */,
-				8BFF17681DF5B4AD005DE734 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1577,20 +1573,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8B6511D82135DE7300ED057B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8B6511F72135DEB400ED057B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8B65120B2135DFC600ED057B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1616,13 +1598,6 @@
 				8B93D8FC20864F7B00CFB01A /* parrot_wide.jpg in Resources */,
 				8B93D90A20866B8600CFB01A /* parrot_srgb.jpg in Resources */,
 				8B93D8F320864D5600CFB01A /* iceland_P3.jpg in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8BA975511D77E2C900601D70 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1664,13 +1639,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B1A49391D78D1BC0003F252 /* TIPTestsResources.bundle in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8BFF17681DF5B4AD005DE734 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TwitterImagePipeline.framework.xcscheme
+++ b/TwitterImagePipeline.xcodeproj/xcshareddata/xcschemes/TwitterImagePipeline.framework.xcscheme
@@ -28,20 +28,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8BA975521D77E2C900601D70"
-               BuildableName = "TIPTests.framework"
-               BlueprintName = "TIPTests"
-               ReferencedContainer = "container:TwitterImagePipeline.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "8BFBD3511AA77DB2007A08DD"
                BuildableName = "TwitterImagePipelineTests.xctest"
                BlueprintName = "TwitterImagePipelineTests"

--- a/TwitterImagePipeline/Project/NSDictionary+TIPAdditions.m
+++ b/TwitterImagePipeline/Project/NSDictionary+TIPAdditions.m
@@ -88,7 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
     TIPAssert(key);
     [self tip_removeObjectsForCaseInsensitiveKey:key];
+#ifndef __clang_analyzer__ // reports key can be nil nil; we prefer to crash if it is
     self[key] = object;
+#endif
 }
 
 - (void)tip_makeAllKeysLowercase

--- a/TwitterImagePipeline/Project/TIPImageRenderedCache.m
+++ b/TwitterImagePipeline/Project/TIPImageRenderedCache.m
@@ -282,7 +282,9 @@ sourceImageDimensions:(CGSize)sourceDims;
                                                                              class:[TIPImagePipelineInspectionResultRenderedEntry class]];
                 TIPAssert(entry != nil);
                 entry.bytesUsed = [entry.image tip_estimatedSizeInBytes];
+#ifndef __clang_analyzer__ // reports entry can be nil; we prefer to crash if it is
                 [inspectedEntries addObject:entry];
+#endif
             }
         }
 

--- a/TwitterImagePipeline/Project/TIPImageStoreAndMoveOperations.m
+++ b/TwitterImagePipeline/Project/TIPImageStoreAndMoveOperations.m
@@ -40,7 +40,9 @@ static NSDictionary<NSString *, id> * __nullable _getDecoderConfigMap(PRIVATE_SE
 static TIPImageContainer * __nullable _getImageContainer(PRIVATE_SELF(TIPImageStoreOperation));
 static TIPCompleteImageEntryContext *_getEntryContext(PRIVATE_SELF(TIPImageStoreOperation),
                                                       NSURL *imageURL,
-                                                      TIPImageContainer * __nullable imageContainer);
+                                                      TIPImageContainer * __nullable imageContainer,
+                                                      NSString * __nullable imageFilePath,
+                                                      NSData * __nullable imageData);
 static void _asyncStoreMemoryEntry(PRIVATE_SELF(TIPImageStoreOperation),
                                    TIPImageCacheEntry *memoryEntry,
                                    void(^complete)(BOOL));
@@ -193,7 +195,11 @@ static void _asyncStoreMemoryEntry(PRIVATE_SELF(TIPImageStoreOperation),
         NSString *identifier = TIPImageStoreRequestGetImageIdentifier(_request);
 
         // Create context
-        TIPCompleteImageEntryContext *context = _getEntryContext(self, imageURL, imageContainer);
+        TIPCompleteImageEntryContext *context = _getEntryContext(self,
+                                                                 imageURL,
+                                                                 imageContainer,
+                                                                 imageFilePath,
+                                                                 imageData);
 
         // Create Memory Entry
         TIPImageCacheEntry *memoryEntry = nil;
@@ -330,7 +336,9 @@ static TIPImageContainer * __nullable _getImageContainer(PRIVATE_SELF(TIPImageSt
 
 static TIPCompleteImageEntryContext *_getEntryContext(PRIVATE_SELF(TIPImageStoreOperation),
                                                       NSURL *imageURL,
-                                                      TIPImageContainer * __nullable imageContainer)
+                                                      TIPImageContainer * __nullable imageContainer,
+                                                      NSString * __nullable imageFilePath,
+                                                      NSData * __nullable imageData)
 {
     TIPAssert(self);
     if (!self) {
@@ -354,6 +362,10 @@ static TIPCompleteImageEntryContext *_getEntryContext(PRIVATE_SELF(TIPImageStore
         context.dimensions = imageContainer.dimensions;
     } else if ([self->_request respondsToSelector:@selector(imageDimensions)]) {
         context.dimensions = self->_request.imageDimensions;
+    } else if (imageData) {
+        context.dimensions = TIPDetectImageDataDimensions(imageData);
+    } else if (imageFilePath) {
+        context.dimensions = TIPDetectImageFileDimensions(imageFilePath);
     }
     if ([self->_request respondsToSelector:@selector(imageType)]) {
         context.imageType = [self->_request imageType];

--- a/TwitterImagePipeline/Project/TIP_Project.m
+++ b/TwitterImagePipeline/Project/TIP_Project.m
@@ -145,7 +145,7 @@ NSString *TIPRawFromSafe(NSString *safe)
     TIPAssert(safe != 0);
     NSString *raw = TIPURLDecodeString(safe, NO);
     TIPAssert(raw != 0);
-    return raw;
+    return (NSString * _Nonnull)raw; // TIPAssert() performed 1 line above
 }
 
 dispatch_block_t __nullable TIPStartBackgroundTask(NSString * __nullable name)

--- a/TwitterImagePipeline/TIPImageUtils.h
+++ b/TwitterImagePipeline/TIPImageUtils.h
@@ -241,4 +241,18 @@ FOUNDATION_EXTERN UIImage * __nullable TIPRenderImage(UIImage * __nullable sourc
                                                       TIPImageRenderFormattingBlock __nullable __attribute__((noescape)) formatBlock,
                                                       TIPImageRenderBlock __attribute__((noescape)) renderBlock);
 
+/**
+ Detect the dimensions of the given image from its data
+ @param data the image data
+ @return the dimensions of the image or `CGSizeZero` if the dimensions could not be determined
+ */
+FOUNDATION_EXTERN CGSize TIPDetectImageDataDimensions(NSData * __nullable data);
+
+/**
+ Detect the dimensions of the given image from its file path
+ @param filePath the image file path
+ @return the dimensions of the image or `CGSizeZero` if the dimensions could not be determined
+ */
+FOUNDATION_EXTERN CGSize TIPDetectImageFileDimensions(NSString * __nullable filePath);
+
 NS_ASSUME_NONNULL_END

--- a/TwitterImagePipeline/UIImage+TIPAdditions.m
+++ b/TwitterImagePipeline/UIImage+TIPAdditions.m
@@ -245,7 +245,7 @@ static UIImage *_UIKitScale(PRIVATE_SELF(UIImage),
     } render:^(UIImage *sourceImage, CGContextRef ctx) {
         [self drawInRect:drawRect];
     }];
-    return image ?: self;
+    return image ?: (UIImage * _Nonnull)self;
 }
 
 static UIImage *_UIKitScaleAnimated(PRIVATE_SELF(UIImage),

--- a/TwitterImagePipelineTests/TIPImagePipelineTests.m
+++ b/TwitterImagePipelineTests/TIPImagePipelineTests.m
@@ -393,6 +393,8 @@
 {
     TestImageStoreRequest *storeRequest = [[TestImageStoreRequest alloc] init];
     storeRequest.imageFilePath = [[self class] pathForImageOfType:TIPImageTypeJPEG progressive:NO];
+    XCTAssertNotNil(storeRequest.imageFilePath);
+
     storeRequest.imageURL = [[self class] dummyURLWithPath:@"dummy.image.jpg"];
     NSString *signalIdentifier = [NSString stringWithFormat:@"%@", @(time(NULL))];
     __block XCTestExpectation *expectation = nil;
@@ -446,7 +448,10 @@
     XCTestExpectation *expectation;
     TIPImageFetchOperation *op;
     NSURL *URL = [NSURL URLWithString:@"http://cross.pipeline.com/image.jpg"];
+
     NSString *imagePath = [[self class] pathForImageOfType:TIPImageTypeJPEG progressive:NO];
+    XCTAssertNotNil(imagePath);
+
     TestImageStoreRequest *storeRequest = [[TestImageStoreRequest alloc] init];
     storeRequest.imageURL = URL;
     storeRequest.imageFilePath = imagePath;

--- a/TwitterImagePipelineTests/TIPTestsSharedUtils.h
+++ b/TwitterImagePipelineTests/TIPTestsSharedUtils.h
@@ -11,6 +11,8 @@
 
 #import "TIPImageDownloader.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 static const uint64_t kKiloBits = 1024 * 8;
 static const uint64_t kMegaBits = 1024 * kKiloBits;
 static const CGSize kCarnivalImageDimensions = { (CGFloat)1880.f, (CGFloat)1253.f };
@@ -33,8 +35,8 @@ static const NSTimeInterval kFireworksAnimationDurations[10] =
 @interface TIPImagePipelineTestFetchRequest : NSObject <TIPImageFetchRequest>
 
 @property (nonatomic) NSURL *imageURL;
-@property (nonatomic, copy) NSString *imageIdentifier;
-@property (nonatomic, copy) TIPImageFetchHydrationBlock imageRequestHydrationBlock;
+@property (nonatomic, copy, nullable) NSString *imageIdentifier;
+@property (nonatomic, copy, nullable) TIPImageFetchHydrationBlock imageRequestHydrationBlock;
 @property (nonatomic) CGSize targetDimensions;
 @property (nonatomic) UIViewContentMode targetContentMode;
 @property (nonatomic) NSTimeInterval timeToLive;
@@ -87,7 +89,9 @@ static const NSTimeInterval kFireworksAnimationDurations[10] =
 @end
 
 @interface TIPImagePipelineBaseTests : XCTestCase <TIPImageFetchDelegate>
-+ (NSString *)pathForImageOfType:(NSString *)type progressive:(BOOL)progressive;
++ (nullable NSString *)pathForImageOfType:(NSString *)type progressive:(BOOL)progressive;
 + (NSURL *)dummyURLWithPath:(NSString *)path;
 + (TIPImagePipeline *)sharedPipeline;
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Fix bugs related to capping the sizes of caches
  - Capping a cache to `0` bytes would not completely disable it as documented, fixed
  - Setting the max ratio value to a negative value would not use the default value as documented, fixed
  - Thanks to @jml5qh for filing this issue (#41)

- Analyzer warning fixes too (not actual bugs)