### PR TITLE
[Idea] Supporting WebP via CocoaPod's subspec

### DIFF
--- a/Extended/TIPXWebPCodec.m
+++ b/Extended/TIPXWebPCodec.m
@@ -15,12 +15,8 @@
 
 #pragma mark WebP includes
 
-#if TARGET_OS_MACCATALYST
-#import <webp/webp.h>
-#else
-#import <WebP/decode.h>
-#import <WebP/encode.h>
-#endif
+#import <libwebp/decode.h>
+#import <libwebp/encode.h>
 
 #pragma mark -
 

--- a/TwitterImagePipeline.podspec
+++ b/TwitterImagePipeline.podspec
@@ -16,5 +16,12 @@ Pod::Spec.new do |s|
     sp.public_header_files = 'TwitterImagePipeline/*.h'
   end
 
+  s.subspec 'WebP' do |sp|
+    sp.source_files = 'Extended/TIPXWebPCodec.{h,m}'
+    sp.public_header_files = 'Extended/TIPXWebPCodec.h'
+    sp.dependency 'TwitterImagePipeline/Default'
+    sp.dependency 'libwebp', '~> 1.0'
+  end
+
   s.default_subspec = 'Default'
 end


### PR DESCRIPTION
Hey! First off, I only recently discovered this library and wow it's impressive! As our project has evolved we've outgrown our existing tool used for managing remotely served images and when I came across TIP it seemed to check all of the boxes for what I was looking for!

We currently also depend on WebP support and I understand why you didn't include it built into TIP however I was wondering if there is any reason not to provide the Codec via an opt-in subspec using CocaPods? 

I see that there is a bit of trickery around getting `libwebp` building for Mac Catalyst however I stubbed across [SDWebImage/libwebp-Xcode](https://github.com/SDWebImage/libwebp-Xcode) and it appears to handle all platforms correctly (although I need to double check that). In the sample PR here, I've added a simple subspec that includes the `TIPXWebPCodec` as well as a dependency on the `libwebp` pod provided by the linked repo and can confirm that this works for my iOS project... Is this approach something that interests you? 

I guess that there are still a few unresolved questions though but I wanted to get opinions before I dig deeper: 

1. Does this work for everything (macCatalyst and so on)?
2. How much work does it take to get `TIPXWebPCodec` up to scratch to release alongside (I noticed a couple of TODO's)
3. Should we somehow auto-register the codec with `TIPImageCodecCatalogue` or leave that up to the user? 

No worries if this isn't something that you want to support in TIP, I just thought that it's better to check here as I'd much rather help give back a little than just integrate something directly into our project 🙏 