### PR TITLE
Add COCOAPODS.md with installation instructions

### DIFF
--- a/COCOAPODS.md
+++ b/COCOAPODS.md
@@ -1,0 +1,55 @@
+# CocoaPods
+
+## Basic Integration
+
+To integrate TIP into your iOS project using CocoaPods, simply add the following to your **Podfile**:
+
+```ruby
+target 'MyApp' do
+  pod 'TwitterImagePipeline', '~> 2.24.1'
+end
+```
+
+Then run a `pod install` inside your terminal, or from CocoaPods.app.
+
+## Extended Integration
+
+TIP also has support for two additional codecs that are not included with the default installation:
+
+- WebP (Backwards compatible to iOS 10)
+- MP4
+
+If you wish to include these codecs, modify your **Podfile** to define the appropriate subspecs like the examples below:
+
+```ruby
+target 'MyApp' do
+  pod 'TwitterImagePipeline', '~> 2.24.1', :subspecs => ['WebPCodec/Default']
+
+  pod 'TwitterImagePipeline', '~> 2.24.1', :subspecs => ['WebPCodec/Animated']
+
+  pod 'TwitterImagePipeline', '~> 2.24.1', :subspecs => ['MP4Codec']
+
+  pod 'TwitterImagePipeline', '~> 2.24.1', :subspecs => ['WebPCodec/Animated', 'MP4']
+end
+```
+
+- **`WebP/Default`**: Includes the `TIPXWebPCodec` with the WebP framework for basic WebP support.
+- **`WebP/Animated`**: Adds additional support to the `TIPXWebPCodec` for demuxing WebP data allowing for animated images.
+- **`MP4Codec`**: Includes the `TIPXMP4Codec`.
+
+**Note:** You are still required to add these codecs to the `TIPImageCodecCatalogue` manually:
+
+```objc
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    TIPImageCodecCatalogue *codecCatalogue = [TIPImageCodecCatalogue sharedInstance];
+
+    [codecCatalogue setCodec:[[TIPXWebPCodec alloc] initPreservingDefaultCodecsIfPresent:NO]
+                forImageType:TIPImageTypeWEBP];
+
+    [codecCatalogue setCodec:[[TIPMP4Codec alloc] init]
+                forImageType:TIPXImageTypeMP4];
+
+    // ...
+}
+```


### PR DESCRIPTION
Following #56, this change adds a **COCOAPODS.md** document describing ways to configure the TwitterImagePipeline pod for use with the extended subspecs.

I was thinking about adding a section to the bottom of **README.md** but wasn't sure if it was best to do that since there are no manual usage instructions to go with it.. Let me know if you want me to add something though.

Once merged, will it be possible to get a 2.24.1 release to push up the new Podspec? I can bump versions or update **CHANGELOG.md** here if it would help? 


Thanks!